### PR TITLE
Fix fs.rename after Node.js v10.0.0

### DIFF
--- a/scripts/build_util.js
+++ b/scripts/build_util.js
@@ -32,7 +32,9 @@ function copyFile(file, target) {
 function renameAsync(from, to) {
 	console.log(from, '----->', to)
 	// @ts-ignore
-	fs.rename(from, to)
+	fs.rename(from, to, (err) => {
+            if (err) throw err;
+        })
 	// fs.renameSync(from,to)
 
 }


### PR DESCRIPTION
Add callback parameter for fs.rename() to build after Node.js v10.0.0.
Signed-Off-By: Yue Yang <metab0t@outlook.com>